### PR TITLE
XAS: Migrate AiiDAlab XAS App to new Repository

### DIFF
--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -7,5 +7,6 @@ How-to guides
    :maxdepth: 1
    :caption: Contents:
 
+   xas_qeapp
    xps_workchain
    xps_qeapp

--- a/docs/source/howto/xas_qeapp.rst
+++ b/docs/source/howto/xas_qeapp.rst
@@ -1,0 +1,193 @@
+==============================
+XANES spectra in AiiDAlab
+==============================
+
+Overview
+--------
+
+Using the XSpectra module of Quantum Espresso, it is possible to calculate X-ray Absorption Near Edge Spectra (XANES) for many types of systems.
+Here we will compute XANES spectra for lithium carbonate (Li\ :sub:`2`\ CO\ :sub:`3`).
+
+Due to the number of calculation steps required, we will need to set up our environment to submit to a remote machine capable of handling the calculation.
+Please refer to the relevant :doc:`How-To </howto/setup_computer_code>` section for this procedure.
+
+.. admonition:: Goal
+
+    To submit an XANES calculation with XSpectra and post-process the results
+
+Start
+-----
+
+To start, go ahead and :doc:`launch </installation/launch>` the app, then follow the steps below.
+
+Step 1: Select a structure
+**************************
+
+Select `Lithium Carbonate` from the `From Examples` tab and click `Confirm`.
+
+.. image:: ../_static/images/XAS_Plugin_Structure_Panel-Li2CO3.png
+
+Step 2: Configure the workflow
+******************************
+
+Select `Full geometry` to relax the structure and set `ElectronicType` to `Insulator`, then select `X-ray absorption spectroscopy (XAS)` as the properties of interest.
+
+For the protocol, select `fast` to quickly produce results, or, if you have enough resources, you can select the `moderate` protocol for increased accuracy.
+
+.. tip::
+    For this example of Li\ :sub:`2`\ CO\ :sub:`3` changing the **K-points distance** to 0.25 from 0.15 in the `advanced settings` tab while using the `moderate` protocol will speed up calculations without compromising accuracy.
+
+.. note::
+    At present the pseudopotential set available for XAS calculations only covers the PBE functional.
+    In order to run the workflow: select the `Advanced settings` tab, navigate to `Accuracy and precision`, tick the `Override` box on the right-hand-side and in the dropdown box under `Exchange-correlation functional` select `PBE`.
+
+    .. image:: ../_static/images/XAS_Plugin-Set_Adv_Options-Alt-Annotated-Cropped.png
+        :scale: 55 %
+        :align: center
+
+Open the `XAS Settings` tab.
+Selection of elements for XANES calculations is found below the explanatory text for the core-hole treatment.
+You may wish to test different treatments for each element to see how this changes the spectra at a later date, however for this example we will use the default values.
+
+    .. image:: ../_static/images/XAS_Plugin_Setting_Panel-Annotated-Cropped.png
+        :scale: 75 %
+        :align: center
+
+Tick the boxes for O and C to select these for calculation, then click `Confirm` to proceed.
+
+Step 3 - Choose computational resources
+***************************************
+
+As mentioned in the overview, our calculation will require more computational resources than the basic tutorial.
+Please make sure to read the relevant :doc:`How-To </howto/setup_computer_code>` section to configure the environment with a remote machine.
+
+Since the workflow uses `xspectra.x` to calculate the XANES spectrum, a code for this will also be required.
+When you're done, click `Submit` to submit the calculation.
+
+.. tip::
+    `xspectra.x` does not require additional conserdiations for installation or setup compared to `pw.x`, so re-using the configuration for the `pw.x` code and changing the executable & plugin entry point will be sufficient.
+
+.. note::
+    As the XSpectra module of Quantum Espresso is not currently able to exploit GPU accelleration, it is strongly recommend to configure this calculation for a non-GPU system if possible.
+
+Step 4: Check the status
+************************
+
+While the calculation is running, you can monitor its status as shown in the :ref:`basic tutorial <basic_status>`.
+You can view the results once the calculation is finished.
+
+Step 5: Spectrum view and post-processing
+*****************************************
+
+Once the calculation is finished, you can view the calculated spectra in the `XAS` tab of the results panel.
+You can change which element to view XANES spectra for using the dropdown box in the top left.
+Select carbon from the dropdown box.
+
+    .. figure:: ../_static/images/XAS_Plugin_Result_Panel-Carbon-Annotated-Cropped.png
+        :scale: 65 %
+        :align: center
+
+        XAS result panel for carbon K-edge of Li\ :sub:`2`\ CO\ :sub:`3`.
+
+.. note::
+    You should notice that "C K-edge" and "Site 4" are listed in the legend to the right of the plot - this is because all carbon atoms in the structure are symmetrically equivalent and thus will produce the same spectrum.
+    The workflow has accounted for this and only calculates the spectrum of the first carbon atom (site number 4 in the structure.)
+
+Immediately below the element selection box are the broadening parameters.
+The XANES spectrum returned by the workflow will initially have a Lorentzian broadening of 0.1 eV.
+As broadening parameters cannot be calculated from first-principles, we will tune these parameters by hand.
+We will first compare to an experimentally-obtained C K-edge spectrum of Li\ :sub:`2`\ CO\ :sub:`3`.
+
+Try changing the first slider (:math:`\Gamma_{hole}`).
+This will initially apply a constant Lorentzian broadening for the entire spectrum.
+Comparing to the experimental reference for carbon, we can see that it is difficult to effectively re-create the experimental spectrum with a constant Lorentzian broadening scheme.
+Setting this to 0 eV will plot the spectrum with no post-processing.
+
+Navigate to the upper center of the XAS panel and tick the box next to `use variable energy broadening`, which will change the behaviour of the broadening tools to use an arctangent-like function commonly used for broadening XANES spectra (see `Calandra & Bunau (2013)`_\ [1]_ for further discussion).
+Set the three sliders in the following configuration:
+
+* :math:`\Gamma_{hole} = 0.3`
+* :math:`\Gamma_{max} = 5.0`
+* :math:`E_{center} = 15`
+
+The resulting spectrum should now more closely resemble the features seen in the experimental example:
+
+.. figure:: ../_static/images/Li2CO3_Example-C_K-edge-XCH_Only-Cropped.png
+    :scale: 75 %
+    :align: center
+
+    Carbon K-edge XRS (low-q)\ [2]_ of Li\ :sub:`2`\ CO\ :sub:`3` compared to the XANES dipole computed with the XCH approximation.
+    Note that computed and experimental spectra are aligned according to the first peak of the signal in this case.
+
+.. tip::
+    For advice with parameter tuning:
+
+    * :math:`\Gamma_{hole}` sets the initial Lorentzian broadening value up to the Fermi level (:math:`E_{F}`, where :math:`E_{F} = 0` eV on the relative energy scale used here). The natural linewidth of the core-hole (if known) typically provides a good reference value (`reference for atomic numbers 10-110`_).
+    * :math:`\Gamma_{max}` sets the "sharpness" of the s-curve of the function - lower values give a smoother change at the inflexion point, while higher values cause the broadening to increase more quickly at the inflexion point.
+    * :math:`E_{center}` sets the energy position of the inflexion point of the function.
+
+   The variable energy function (:math:`\Gamma(\Omega)`) and its parameters can be visualised in the following plot (from Fig.1 of `Calandra & Bunau (2013)`_\ [1]_):
+
+    .. image:: ../_static/images/Calandra_Bunau-PRB-205105-2013-gamma_func_plot.png
+        :scale: 33 %
+        :align: center
+
+
+Next, select the oxygen K-edge spectrum using the dropdown box in the upper left.
+With the broadening scheme used for carbon, the spectrum should already resemble the experimental spectrum quite well, though you may try to tune the parameters further if desired - particularly increasing the initial broadening (:math:`\Gamma_{hole}`):
+
+.. figure:: ../_static/images/Li2CO3_Example-O_K-edge-FCH_Only-Cropped.png
+    :scale: 75 %
+    :align: center
+
+    O K-edge total electron yield (TEY)\ [3]_ XAS spectrum compared to the XANES dipole computed with the FCH approximation.
+    Here, the broadening scheme used for carbon is modified such that :math:`\Gamma_{hole} = 0.8` eV.
+    Note that computed and experimental spectra are aligned according to the first peak of the signal in this case.
+
+In the plot window, you should be able to see three different plots: One for the full O K-edge and one for each of the two symmetrically-inequivalent oxygen atoms.
+The component spectra in each case are first normalised, then the intensities are scaled according to the site multiplicity.
+
+.. image:: ../_static/images/XAS_Plugin_Result_Panel-Oxygen.png
+
+Click on a spectrum in the legend to show/hide it in the viewer.
+Click and drag a box over the plot area to zoom in to the selected region.
+Double-click to zoom out to the full spectrum.
+
+Finally, click on the "Download CSV" button to the upper left of the plot area to download a CSV file of the XAS plots for the selected element in order to export the spectrum for further analysis.
+
+.. note::
+    The CSV file will contain all component spectra for the selected element.
+    Any broadening applied to the spectrum *via* the available tools will be applied to the data in the CSV file.
+    If multiple inequivalent absorbing atoms are present, the CSV file will contain one column for the total and two for each component:
+
+    * The normalised & weighted spectrum. (with respect to ratio of site multiplicity to total multiplicity)
+    * The normalised & un-weighted spectrum.
+
+Additional Note on Charged Systems
+----------------------------------
+Computing XANES spectra for systems where a charge has been applied (in this case using the `Total charge` advanced setting) is possible using the tools
+available in the QE App, however such workflows should always be tested by the user against experimental data if possible.
+
+When running XAS workflows for systems where a total charge has been applied, it is suggested to use the following settings for the total charge to ensure the corresponding
+core-hole treatment is applied correctly:
+
+* "xch_fixed" or "xch_smear": Set the total charge as required for the system's charged ground-state.
+* "full": **Increase** the total charge by 1 *relative* to the system's charged ground-state (e.g. set total charge = 2 in the advanced settings tab if the charge is normally 1).
+
+Note that for neutral systems (total charge = 0), the QE App will handle these settings automatically.
+
+Summary
+-------
+
+Here, you learned how to submit an XANES calculation on a remote machine using the Quantum ESPRESSO app and how to effectively use the post-processing tools.
+
+.. rubric:: References
+
+.. [1] O\. Bunau and M. Calandra, *Phys. Rev. B*, **87**, 205105 (2013) https://dx.doi.org/10.1103/PhysRevB.87.205105
+.. [2] E\. de Clermont Gallerande *et al*, *Phys. Rev. B*, **98**, 214104, (2018) https://dx.doi.org/10.1103/PhysRevB.98.214104
+.. [3] R\. Qiao *et al*, *Plos ONE*, **7**, e49182 (2012) https://dx.doi.org/doi:10.1371/journal.pone.0049182
+
+.. _reference for atomic numbers 10-110: https://dx.doi.org/10.1063/1.555595
+.. _inelastic mean free path: https://dx.doi.org/10.1002/sia.740010103
+.. _Calandra & Bunau (2013): https://dx.doi.org/10.1103/PhysRevB.87.205105
+.. _PEP 440 version specifier: https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ requires-python = '>=3.9'
 "xspec.xspectra.crystal" = "aiida_qe_xspec.workflows.xspectra.base:XspectraCrystalWorkChain"
 
 [project.entry-points."aiidalab_qe.properties"]
+"xas" = "aiida_qe_xspec.gui.xas:xas"
 "xps" = "aiida_qe_xspec.gui.xps:xps"
 
 [project.optional-dependencies]

--- a/src/aiida_qe_xspec/gui/xas/__init__.py
+++ b/src/aiida_qe_xspec/gui/xas/__init__.py
@@ -1,0 +1,43 @@
+from importlib import resources as importlib_resources
+
+import yaml
+
+from aiidalab_qe.common.panel import PluginOutline
+from aiidalab_qe.plugins import xas as xas_folder
+
+from .model import XasConfigurationSettingsModel
+from .resources import XasResourceSettingsModel, XasResourceSettingsPanel
+from .result import XasResultsModel, XasResultsPanel
+from .setting import XasConfigurationSettingsPanel
+from .structure_examples import structure_examples
+from .workchain import workchain_and_builder
+
+PSEUDO_TOC = yaml.safe_load(
+    importlib_resources.read_text(
+        xas_folder,
+        'pseudo_toc.yaml',
+    )
+)
+
+
+class XasPluginOutline(PluginOutline):
+    title = 'X-ray absorption spectroscopy (XAS)'
+
+
+xas = {
+    'outline': XasPluginOutline,
+    'structure_examples': structure_examples,
+    'configuration': {
+        'panel': XasConfigurationSettingsPanel,
+        'model': XasConfigurationSettingsModel,
+    },
+    'resources': {
+        'panel': XasResourceSettingsPanel,
+        'model': XasResourceSettingsModel,
+    },
+    'result': {
+        'panel': XasResultsPanel,
+        'model': XasResultsModel,
+    },
+    'workchain': workchain_and_builder,
+}

--- a/src/aiida_qe_xspec/gui/xas/model.py
+++ b/src/aiida_qe_xspec/gui/xas/model.py
@@ -1,0 +1,232 @@
+import os
+import tarfile
+from importlib import resources
+from pathlib import Path
+
+import requests
+import traitlets as tl
+import yaml
+
+from aiida import orm
+from aiidalab_qe.common.mixins import HasInputStructure
+from aiidalab_qe.common.panel import ConfigurationSettingsModel
+from aiidalab_qe.plugins import xas as xas_folder
+
+
+class XasConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
+    title = 'XAS'
+    identifier = 'xas'
+
+    dependencies = [
+        'input_structure',
+    ]
+
+    # structure_type_options = tl.List(
+    #     trait=tl.List(tl.Unicode(), tl.Unicode()),
+    #     default_value=[
+    #         ["Molecule", "molecule"],
+    #         ["Crystal", "crystal"],
+    #     ],
+    # )
+    # structure_type = tl.Unicode("crystal")
+
+    supercell_min_parameter = tl.Float(8.0)
+
+    kind_names = tl.Dict(
+        key_trait=tl.Unicode(),  # kind name
+        value_trait=tl.Bool(),  # whether the element is included
+    )
+    core_hole_treatments_options = tl.List(
+        trait=tl.List(tl.Unicode()),
+        default_value=[
+            ['FCH', 'full'],
+            ['XCH (Smearing)', 'xch_smear'],
+            ['XCH (Fixed)', 'xch_fixed'],
+        ],
+    )
+    core_hole_treatments = tl.Dict(
+        key_trait=tl.Unicode(),  # kind name
+        value_trait=tl.Unicode(),  # core hole treatment type
+        default_value={},
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        PSEUDO_TOC: dict = yaml.safe_load(
+            resources.read_text(
+                xas_folder,
+                'pseudo_toc.yaml',
+            ),
+        )  # type: ignore
+
+        self.pseudo_data_dict = PSEUDO_TOC['pseudos']
+        self.xch_elements = PSEUDO_TOC['xas_xch_elements']
+        self.base_url = (
+            'https://github.com/PNOGillespie/Core_Level_Spectra_Pseudos/raw/main'
+        )
+        self.head_path = f'{Path.home()}/.local/lib'
+        self.dir_header = 'cls_pseudos'
+        self.functionals = ['pbe']
+        self.core_wfc_dir = 'core_wfc_data'
+        self.gipaw_dir = 'gipaw_pseudos'
+        self.ch_pseudo_dir = 'ch_pseudos/star1s'
+        self.gipaw_pseudos = self.pseudo_data_dict['pbe']['gipaw_pseudos']
+        self.core_hole_pseudos = self.pseudo_data_dict['pbe']['core_hole_pseudos']['1s']
+        self.core_wfc_data_dict = self.pseudo_data_dict['pbe']['core_wavefunction_data']
+
+        self.installed_pseudos = False
+
+    def update(self, specific=''):  # noqa: ARG002
+        with self.hold_trait_notifications():
+            self._update_pseudos()
+            self._update_core_hole_treatment_recommendations()
+
+    def get_model_state(self):
+        pseudo_labels = {}
+        core_wfc_data_labels = {}
+        for element in self.kind_names.keys():
+            pseudo_labels[element] = {
+                'gipaw': self.gipaw_pseudos[element],
+                'core_hole': self.core_hole_pseudos[element],
+            }
+            core_wfc_data_labels[element] = self.core_wfc_data_dict[element]
+
+        return {
+            # "structure_type": self.structure_type,
+            'elements_list': list(self.kind_names.keys()),
+            'core_hole_treatments': self.core_hole_treatments,
+            'pseudo_labels': pseudo_labels,
+            'core_wfc_data_labels': core_wfc_data_labels,
+            'supercell_min_parameter': self.supercell_min_parameter,
+        }
+
+    def set_model_state(self, parameters: dict):
+        self.kind_names = {
+            kind_name: kind_name in parameters['elements_list']
+            for kind_name in self.kind_names
+        }
+
+        self.core_hole_treatments = {
+            kind_name: parameters['core_hole_treatments'].get(kind_name, 'full')
+            for kind_name in self.kind_names
+        }
+
+        self.supercell_min_parameter = parameters.get('supercell_min_parameter', 8.0)
+        # self.structure_type = parameters.get("structure_type", "crystal")
+
+    def get_kind_names(self):
+        return list(self.kind_names)
+
+    def get_recommendation(self, element):
+        return 'xch_smear' if element in self.xch_elements else 'full'
+
+    def reset(self):
+        with self.hold_trait_notifications():
+            self.supercell_min_parameter = self.traits()[
+                'supercell_min_parameter'
+            ].default_value
+            # self.structure_type = self.traits()["structure_type"].default_value
+
+    def _update_pseudos(self):
+        if self.installed_pseudos:
+            return
+
+        for func in self.functionals:
+            target_dir = f'{self.head_path}/{self.dir_header}/{func}'
+            os.makedirs(target_dir, exist_ok=True)
+            archive_filename = f'{func}_ch_pseudos.tgz'
+            archive_found = any(
+                entry == archive_filename for entry in os.listdir(target_dir)
+            )
+            if not archive_found:
+                self._download_extract_pseudo_archive(func)
+
+        # Check all the pseudos/core-wfc data files in the TOC dictionary
+        # and load/check all of them before proceeding. Note that this
+        # approach relies on there not being multiple instances of nodes
+        # with the same label.
+        for func in self.functionals:
+            gipaw_pseudo_dict = self.pseudo_data_dict[func]['gipaw_pseudos']
+            core_wfc_dict = self.pseudo_data_dict[func]['core_wavefunction_data']
+            core_hole_pseudo_dict = self.pseudo_data_dict[func]['core_hole_pseudos']
+            main_path = f'{self.head_path}/{self.dir_header}/{func}'
+            core_wfc_dir = f'{main_path}/core_wfc_data'
+            gipaw_dir = f'{main_path}/gipaw_pseudos'
+            ch_pseudo_dir = f'{main_path}/ch_pseudos/star1s'
+            # First, check that the local directories contain what's in the pseudo_toc
+            for pseudo_dir, pseudo_dict in zip(
+                [gipaw_dir, core_wfc_dir, ch_pseudo_dir],
+                [gipaw_pseudo_dict, core_wfc_dict, core_hole_pseudo_dict],
+            ):
+                pseudo_toc_mismatch = os.listdir(pseudo_dir) != pseudo_dict.values()
+
+            # Re-download the relevant archive if there is a mismatch
+            if pseudo_toc_mismatch:
+                self._download_extract_pseudo_archive(func)
+
+            self._load_or_import_nodes_from_filenames(
+                in_dict=gipaw_pseudo_dict,
+                path=gipaw_dir,
+            )
+            self._load_or_import_nodes_from_filenames(
+                in_dict=core_wfc_dict,
+                path=core_wfc_dir,
+                core_wfc_data=True,
+            )
+            self._load_or_import_nodes_from_filenames(
+                in_dict=core_hole_pseudo_dict['1s'],
+                path=ch_pseudo_dir,
+            )
+
+        self.installed_pseudos = True
+
+    def _load_or_import_nodes_from_filenames(self, in_dict, path, core_wfc_data=False):
+        for filename in in_dict.values():
+            try:
+                orm.load_node(filename)
+            except BaseException:
+                if not core_wfc_data:
+                    new_upf = orm.UpfData(f'{path}/{filename}', filename=filename)
+                    new_upf.label = filename
+                    new_upf.store()
+                else:
+                    new_singlefile = orm.SinglefileData(
+                        f'{path}/{filename}', filename='stdout'
+                    )
+                    new_singlefile.label = filename
+                    new_singlefile.store()
+
+    def _download_extract_pseudo_archive(self, func):
+        target_dir = f'{self.head_path}/{self.dir_header}/{func}'
+        archive_filename = f'{func}_ch_pseudos.tgz'
+        remote_archive_filename = f'{self.base_url}/{func}/{archive_filename}'
+        local_archive_filename = f'{target_dir}/{archive_filename}'
+
+        env = os.environ.copy()
+        env['PATH'] = f"{env['PATH']}:{Path.home() / '.local' / 'lib'}"
+
+        response = requests.get(remote_archive_filename, timeout=30)
+        response.raise_for_status()
+        with open(local_archive_filename, 'wb') as handle:
+            handle.write(response.content)
+            handle.flush()
+            response.close()
+
+        with tarfile.open(local_archive_filename, 'r:gz') as tarfil:
+            tarfil.extractall(target_dir)
+
+    def _update_core_hole_treatment_recommendations(self):
+        if not self.has_structure:
+            self.kind_names = {}
+            self.core_hole_treatments = {}
+        else:
+            self.kind_names = {
+                kind_name: self.kind_names.get(kind_name, False)
+                for kind_name in self.input_structure.get_kind_names()
+                if kind_name in self.core_hole_pseudos
+            }
+            self.core_hole_treatments = {
+                kind_name: self.get_recommendation(kind_name)
+                for kind_name in self.kind_names
+            }

--- a/src/aiida_qe_xspec/gui/xas/pseudo_toc.yaml
+++ b/src/aiida_qe_xspec/gui/xas/pseudo_toc.yaml
@@ -1,0 +1,25 @@
+xas_xch_elements: [C, Li]
+pseudos:
+  pbe:
+    gipaw_pseudos:
+      C: C.pbe-n-kjgipaw_psl.1.0.0.UPF
+      Cu: Cu.pbe-n-van_gipaw.UPF
+      F: F.pbe-gipaw_kj_no_hole.UPF
+      Li: Li.pbe-s-rrkjus-gipaw.UPF
+      O: O.pbe-n-kjpaw_gipaw.UPF
+      Si: Si.pbe-van_gipaw.UPF
+    core_wavefunction_data:
+      C: C.pbe-n-kjgipaw_psl.1.0.0.dat
+      Cu: Cu.pbe-n-van_gipaw.dat
+      F: F.pbe-gipaw_kj_no_hole.dat
+      Li: Li.pbe-s-rrkjus-gipaw.dat
+      O: O.pbe-n-kjpaw_gipaw.dat
+      Si: Si.pbe-van_gipaw.dat
+    core_hole_pseudos:
+      1s:
+        C: C.star1s.pbe-n-kjgipaw_psl.1.0.0.UPF
+        Cu: Cu.star1s-pbe-n-van_gipaw.UPF
+        F: F.star1s-pbe-gipaw_kj.UPF
+        Li: Li.star1s-pbe-s-rrkjus-gipaw-test_2.UPF
+        O: O.star1s.pbe-n-kjpaw_gipaw.UPF
+        Si: Si.star1s-pbe-van_gipaw.UPF

--- a/src/aiida_qe_xspec/gui/xas/resources.py
+++ b/src/aiida_qe_xspec/gui/xas/resources.py
@@ -1,0 +1,37 @@
+"""Panel for XAS plugin."""
+
+from aiidalab_qe.common.code.model import CodeModel, PwCodeModel
+from aiidalab_qe.common.panel import (
+    PluginResourceSettingsModel,
+    PluginResourceSettingsPanel,
+)
+
+
+class XasResourceSettingsModel(PluginResourceSettingsModel):
+    """Model for the XAS plugin."""
+
+    title = 'XAS'
+    identifier = 'xas'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_models(
+            {
+                'pw': PwCodeModel(
+                    name='pw.x',
+                    description='pw.x',
+                    default_calc_job_plugin='quantumespresso.pw',
+                ),
+                'xspectra': CodeModel(
+                    name='xspectra.x',
+                    description='xspectra.x',
+                    default_calc_job_plugin='quantumespresso.xspectra',
+                ),
+            }
+        )
+
+
+class XasResourceSettingsPanel(
+    PluginResourceSettingsPanel[XasResourceSettingsModel],
+):
+    """Panel for configuring the XAS plugin."""

--- a/src/aiida_qe_xspec/gui/xas/result/__init__.py
+++ b/src/aiida_qe_xspec/gui/xas/result/__init__.py
@@ -1,0 +1,7 @@
+from .model import XasResultsModel
+from .result import XasResultsPanel
+
+__all__ = [
+    'XasResultsModel',
+    'XasResultsPanel',
+]

--- a/src/aiida_qe_xspec/gui/xas/result/model.py
+++ b/src/aiida_qe_xspec/gui/xas/result/model.py
@@ -1,0 +1,136 @@
+import numpy as np
+import traitlets as tl
+from scipy.interpolate import make_interp_spline
+
+from aiidalab_qe.common.panel import ResultsModel
+
+from .utils import broaden_xas, export_xas_data, get_aligned_spectra
+
+
+class XasResultsModel(ResultsModel):
+    title = 'XAS'
+    identifier = 'xas'
+
+    spectrum_options = tl.List(
+        trait=tl.Unicode(),
+        default_value=[],
+    )
+    spectrum = tl.Unicode(None, allow_none=True)
+    variable_broad = tl.Bool(False)
+    gamma_hole = tl.Float(0.0)
+    gamma_max = tl.Float(5.0)
+    center_e = tl.Float(15.0)
+
+    final_spectra = {}
+    equivalent_sites_data = {}
+    core_workchain_dict = {}
+
+    total_multiplicity = 0
+
+    _this_process_label = 'XspectraCrystalWorkChain'
+
+    def update_spectrum_options(self):
+        if not (process_node := self.fetch_process_node()):
+            return
+        outputs = self._get_child_outputs()
+        (
+            self.final_spectra,
+            self.equivalent_sites_data,
+        ) = export_xas_data(outputs)
+        xas_workchain = next(
+            node
+            for node in process_node.called
+            if node.process_label == self._this_process_label
+        )
+        core_workchains = {
+            node.get_metadata_inputs()['metadata']['call_link_label']: node
+            for node in xas_workchain.called
+            if node.process_label == 'XspectraCoreWorkChain'
+        }
+        self.core_workchain_dict = {
+            key.replace('_xspectra', ''): value
+            for key, value in core_workchains.items()
+        }
+        options = [key.split('_')[0] for key in self.final_spectra.keys()]
+        self.spectrum_options = options
+        self.spectrum = options[0] if options else None
+
+    def get_data(self):
+        chosen_spectrum_label = f'{self.spectrum}_xas'
+
+        element_sites = [
+            key
+            for key in self.equivalent_sites_data
+            if self.equivalent_sites_data[key]['symbol'] == self.spectrum
+        ]
+
+        element_core_workchains = {}
+        self.total_multiplicity = 0
+        for site in element_sites:
+            self.total_multiplicity += self.equivalent_sites_data[site]['multiplicity']
+            element_core_workchains[site] = self.core_workchain_dict[site]
+
+        final_spectrum_node = self.final_spectra[chosen_spectrum_label]
+        final_spectrum = np.column_stack(
+            (
+                final_spectrum_node.get_x()[1],
+                final_spectrum_node.get_y()[0][1],
+            )
+        )
+        final_x_vals = final_spectrum[:, 0]
+        final_y_vals = final_spectrum[:, 1]
+        final_spectrum_spline = make_interp_spline(final_x_vals, final_y_vals)
+        integral = np.trapz(final_spectrum_spline(final_x_vals), final_x_vals)
+        final_norm_y = final_spectrum_spline(final_x_vals) / integral
+
+        spectra = [
+            (
+                f'{self.spectrum} K-edge',
+                1,
+                '1',
+                np.column_stack((final_x_vals, final_norm_y)),
+            )
+        ]
+
+        for entry in get_aligned_spectra(
+            core_wc_dict=element_core_workchains,
+            equivalent_sites_dict=self.equivalent_sites_data,
+        ):
+            spectra.append(entry)
+
+        datasets = []
+        for entry in spectra:
+            label = entry[0]
+            weighting = entry[1]
+            weighting_string = entry[2]
+            raw_spectrum = entry[-1]
+            x = raw_spectrum[:, 0]
+            y = raw_spectrum[:, 1]
+
+            if self.gamma_hole == 0.0:
+                x = raw_spectrum[:, 0]
+                y = raw_spectrum[:, 1]
+            else:
+                broad_spectrum = broaden_xas(
+                    raw_spectrum,
+                    gamma_hole=self.gamma_hole,
+                    gamma_max=self.gamma_max,
+                    center_energy=self.center_e,
+                    variable=self.variable_broad,
+                )
+                x = broad_spectrum[:, 0]
+                y = broad_spectrum[:, 1]
+
+            final_spline = make_interp_spline(x, y)
+            final_y_vals = final_spline(final_x_vals)
+            datasets.append(
+                {
+                    'x': final_x_vals,
+                    'y': final_y_vals,
+                    'name': label,
+                    'weighting': weighting,
+                    'weighting_string': weighting_string,
+                }
+            )
+
+        return datasets

--- a/src/aiida_qe_xspec/gui/xas/result/result.py
+++ b/src/aiida_qe_xspec/gui/xas/result/result.py
@@ -1,0 +1,217 @@
+"""XAS results view widgets"""
+
+import ipywidgets as ipw
+import plotly.graph_objects as go
+
+from aiidalab_qe.common.panel import ResultsPanel
+
+from .model import XasResultsModel
+from .spectrum_button import SpectrumDownloadButton
+from .utils import write_csv
+
+
+class XasResultsPanel(ResultsPanel[XasResultsModel]):
+    def _render(self):
+        variable_broad_select = ipw.Checkbox(
+            description='Use variable energy broadening.',
+            style={'description_width': 'initial', 'opacity': 0.5},
+        )
+        ipw.link(
+            (self._model, 'variable_broad'),
+            (variable_broad_select, 'value'),
+        )
+        variable_broad_select.observe(
+            self._update_plot,
+            'value',
+        )
+
+        gamma_hole_select = ipw.FloatSlider(
+            min=0.0,
+            max=5,
+            step=0.1,
+            description=r'$\Gamma_{hole}$',
+            continuous_update=True,
+            orientation='horizontal',
+            readout=True,
+        )
+        ipw.link(
+            (self._model, 'gamma_hole'),
+            (gamma_hole_select, 'value'),
+        )
+        gamma_hole_select.observe(
+            self._update_plot,
+            'value',
+        )
+
+        gamma_max_select = ipw.FloatSlider(
+            min=2.0,
+            max=10,
+            step=0.5,
+            continuous_update=True,
+            description=r'$\Gamma_{max}$',
+            orientation='horizontal',
+            readout=True,
+        )
+        ipw.link(
+            (self._model, 'gamma_max'),
+            (gamma_max_select, 'value'),
+        )
+        ipw.dlink(
+            (self._model, 'variable_broad'),
+            (gamma_max_select, 'disabled'),
+            lambda value: not value,
+        )
+        gamma_max_select.observe(
+            self._update_plot,
+            'value',
+        )
+
+        center_e_select = ipw.FloatSlider(
+            min=5,
+            max=30,
+            step=0.5,
+            continuous_update=True,
+            description=r'$E_{center}$',
+            orientation='horizontal',
+            readout=True,
+        )
+        ipw.link(
+            (self._model, 'center_e'),
+            (center_e_select, 'value'),
+        )
+        ipw.dlink(
+            (self._model, 'variable_broad'),
+            (center_e_select, 'disabled'),
+            lambda value: not value,
+        )
+        center_e_select.observe(
+            self._update_plot,
+            'value',
+        )
+
+        spectrum_select = ipw.Dropdown(
+            description='',
+            layout=ipw.Layout(width='20%'),
+        )
+        ipw.dlink(
+            (self._model, 'spectrum_options'),
+            (spectrum_select, 'options'),
+        )
+        ipw.link(
+            (self._model, 'spectrum'),
+            (spectrum_select, 'value'),
+        )
+        spectrum_select.observe(
+            self._update_plot,
+            'value',
+        )
+
+        self.download_data = SpectrumDownloadButton(
+            filename=f'{spectrum_select.value}_XAS_Spectra.csv',
+            contents=None,
+            description='Download CSV',
+            icon='download',
+        )
+        self.download_data.observe(
+            self._update_plot,
+            ['contents', 'filename'],
+        )
+
+        self.plot = go.FigureWidget(
+            layout=go.Layout(
+                title={'text': 'XAS'},
+                barmode='overlay',
+            )
+        )
+        self.plot.layout.xaxis.title = 'Relative Photon Energy (eV)'
+
+        self.results_container.children = [
+            ipw.HBox(
+                [
+                    ipw.VBox(
+                        [
+                            ipw.HTML("""
+                                <div style="line-height: 140%; padding-top: 0px; padding-bottom: 0px; opacity:0.5;">
+                                    <b>Select spectrum to plot</b>
+                                </div>
+                            """),
+                            spectrum_select,
+                            ipw.HTML("""
+                                <div style="line-height: 140%; padding-top: 0px; padding-bottom: 10px; opacity:0.5;">
+                                    <b>Select parameters for spectrum broadening </b>
+                                </div>
+                            """),
+                            gamma_hole_select,
+                            gamma_max_select,
+                            center_e_select,
+                        ],
+                        layout=ipw.Layout(width='40%'),
+                    ),
+                    ipw.VBox(
+                        [
+                            variable_broad_select,
+                            # PNOG: If someone knows a way to format certain words differently in HTML without causing a line-break, hit me up.
+                            # For now, (17/10/23) we'll just have the function terms be in italics.
+                            # Alternatively, if it's possible to format mathematical terms in HTML without a line-break, let me know
+                            ipw.HTML("""
+                                <div style="line-height: 140%; padding-top: 5px; padding-bottom: 5px; opacity:0.5;">
+                                    <b>Broadening parameters:</b>
+                                        <p style="padding-bottom: 5px">
+                                            <i style="font-size:14pt;font-family:Times New Roman">&Gamma;<sub><em>hole</em></sub></i> - Defines a constant Lorenzian broadening width for the whole spectrum. In "variable" mode, defines the initial broadening width of the ArcTangent function. </p>
+                                        <p style="padding-bottom: 5px"> <i style="font-size:14pt;font-family:Times New Roman">&Gamma;<sub><em>max</em></sub></i> - Maximum Lorenzian broadening parameter at infinite energy in "variable" mode.</p>
+                                        <p style="padding-bottom: 5px"> <i style="font-size:14pt;font-family:Times New Roman"><em>E<sub>center</em></sub></i> - Defines the inflection point of the variable-energy broadening function.</p>
+                                    </div>
+                                    <div style="line-height: 140%; padding-top: 5px; padding-bottom: 5px; opacity:0.5;">
+                                    <b>Note that setting <i style="font-size:14pt;font-family:Times New Roman">&Gamma;<sub><em>hole</em></sub></i> to 0 eV will simply plot the raw spectrum.</b>
+                                </div>
+                            """),
+                        ],
+                        layout=ipw.Layout(width='60%'),
+                    ),
+                ]
+            ),
+            self.download_data,
+            self.plot,
+        ]
+
+    def _post_render(self):
+        self._model.update_spectrum_options()
+
+    def _update_plot(self, _):
+        if not self.rendered:
+            return
+
+        datasets = self._model.get_data()
+        self._update_download_selection(datasets, self._model.spectrum)
+
+        with self.plot.batch_update():
+            # If the number of datasets is different from one update to the next,
+            # then we need to reset the data already in the Widget. Otherwise, we can
+            # simply override the data. This also helps since then changing the
+            # broadening is much smoother.
+
+            # if the number of entries is the same, just update
+            if len(datasets) == len(self.plot.data):
+                for index, entry in enumerate(datasets):
+                    self.plot.data[index].x = entry['x']
+                    self.plot.data[index].y = entry['y']
+                    if 'site_' in entry['name']:
+                        self.plot.data[index].name = (
+                            entry['name'].capitalize().replace('_', ' ')
+                        )
+                    else:
+                        self.plot.data[index].name = entry['name']
+
+            # otherwise, reset the figure
+            else:
+                self.plot.data = ()
+                for entry in datasets:
+                    if 'site_' in entry['name']:
+                        name = entry['name'].capitalize().replace('_', ' ')
+                    else:
+                        name = entry['name']
+                    self.plot.add_scatter(x=entry['x'], y=entry['y'], name=name)
+
+    def _update_download_selection(self, dataset, element):
+        self.download_data.contents = lambda: write_csv(dataset)
+        self.download_data.filename = f'{element}_XAS_Spectra.csv'

--- a/src/aiida_qe_xspec/gui/xas/result/spectrum_button.py
+++ b/src/aiida_qe_xspec/gui/xas/result/spectrum_button.py
@@ -1,0 +1,47 @@
+import base64
+import hashlib
+from typing import Callable
+
+import ipywidgets as ipw
+from IPython.display import HTML, display
+
+
+class SpectrumDownloadButton(ipw.Button):
+    """Download button with dynamic content
+    The content is generated using a callback when the button is clicked.
+    Modified from responses to https://stackoverflow.com/questions/61708701/how-to-download-a-file-using-ipywidget-button#62641240
+    """
+
+    def __init__(self, filename: str, contents: Callable[[], str], **kwargs):
+        super().__init__(**kwargs)
+        self.filename = filename
+        self.contents = contents
+        self.on_click(self.__on_click)
+
+    def __on_click(self, _):
+        if self.contents is None:
+            return
+
+        contents: bytes = self.contents().encode('utf-8')
+        b64 = base64.b64encode(contents)
+        payload = b64.decode()
+        digest = hashlib.md5(contents).hexdigest()  # bypass browser cache
+        link_id = f'dl_{digest}'
+
+        display(
+            HTML(
+                f"""
+            <html>
+            <body>
+            <a id="{link_id}" download="{self.filename}" href="data:text/csv;base64,{payload}" download>
+            </a>
+            <script>
+            (function download() {{
+            document.getElementById('{id}').click();
+            }})()
+            </script>
+            </body>
+            </html>
+        """
+            )
+        )

--- a/src/aiida_qe_xspec/gui/xas/result/utils.py
+++ b/src/aiida_qe_xspec/gui/xas/result/utils.py
@@ -1,0 +1,185 @@
+import numpy as np
+from scipy.interpolate import make_interp_spline
+
+
+def write_csv(dataset):
+    from pandas import DataFrame
+
+    x_vals = dataset[0]['x']
+    df_data = {'energy_ev': x_vals}
+    for entry in dataset:
+        if 'site' in entry['name']:
+            if entry['weighting'] != 1:
+                df_data[
+                    f'{entry["name"].capitalize().replace("_", " ")} (Weighted)'
+                ] = entry['y']
+                df_data[
+                    f'{entry["name"].capitalize().replace("_", " ")} (Unweighted)'
+                ] = entry['y'] / entry['weighting']
+            else:
+                df_data[entry['name'].capitalize().replace('_', ' ')] = entry['y']
+        else:
+            df_data[entry['name']] = entry['y']
+
+    df = DataFrame(data=df_data)
+    df_energy_indexed = df.set_index('energy_ev')
+
+    return df_energy_indexed.to_csv(header=True)
+
+
+def export_xas_data(outputs):
+    final_spectra = {}
+    equivalent_sites_data = {}
+    if 'final_spectra' in outputs:
+        final_spectra = outputs.final_spectra
+        symmetry_analysis_data = outputs.symmetry_analysis_data.get_dict()
+        equivalent_sites_data = symmetry_analysis_data['equivalent_sites_data']
+    return (
+        final_spectra,
+        equivalent_sites_data,
+    )
+
+
+def broaden_xas(
+    input_array, variable=False, gamma_hole=0.01, gamma_max=5, center_energy=15
+):
+    """Take an input spectrum and return a broadened spectrum as output using either a constant or variable parameter.
+
+    :param input_array: The 2D array of x/y values to be broadened. Should be plotted with
+                        little or no broadening before using the function.
+    :param gamma_hole: The broadening parameter for the Lorenzian broadening function. In constant mode (variable=False),
+                       this value is applied to the entire spectrum. In variable mode (variable=True), this value defines
+                       the starting broadening parameter of the arctangent function. Refers to the natural linewidth of
+                       the element/XAS edge combination in question and (for elements Z > 10) should be based on reference
+                       values from X-ray spectroscopy.
+    :param variable: Request a variable-energy broadening of the spectrum instead of the defaultconstant broadening.
+                     Uses the functional form defined in Calandra and Bunau, PRB, 87, 205105 (2013).
+    :param gamma_max: The maximum lorenzian broadening to be applied in variable energy broadening mode. Refers to the
+                      broadening effects at infinite energy above the main edge.
+    :param center_energy: The inflection point of the variable broadening function. Does not relate to experimental data
+                          and must be tuned manually.
+    """
+
+    if variable:
+        if not all([gamma_hole, gamma_max, center_energy]):
+            missing = [
+                i[0]
+                for i in zip(
+                    ['gamma_hole', 'gamma_max', 'center_energy'],
+                    [gamma_hole, gamma_max, center_energy],
+                )
+                if i[1] is None
+            ]
+            raise ValueError(
+                f'The following variables were not defined {missing} and are required for variable-energy broadening'
+            )
+
+    x_vals = input_array[:, 0]
+    y_vals = input_array[:, 1]
+
+    lorenz_y = np.zeros(len(x_vals))
+
+    if variable:
+        for x, y in zip(x_vals, y_vals):
+            if x < 0:  # the function is bounded between gamma_hole and gamma_max
+                gamma_var = gamma_hole
+            else:
+                e = x / center_energy
+
+                gamma_var = gamma_hole + gamma_max * (
+                    0.5 + np.arctan((e - 1) / (e**2)) / np.pi
+                )
+
+            if y <= 1.0e-6:  # do this to skip the calculation for very small values
+                lorenz_y = y
+            else:
+                lorenz_y += (
+                    gamma_var
+                    / 2.0
+                    / np.pi
+                    / ((x_vals - x) ** 2 + 0.25 * gamma_var**2)
+                    * y
+                )
+    else:
+        for x, y in zip(x_vals, y_vals):
+            lorenz_y += (
+                gamma_hole
+                / 2.0
+                / np.pi
+                / ((x_vals - x) ** 2 + 0.25 * gamma_hole**2)
+                * y
+            )
+
+    return np.column_stack((x_vals, lorenz_y))
+
+
+def get_aligned_spectra(core_wc_dict, equivalent_sites_dict):
+    """Return a set of spectra aligned according to the chemical shift (difference in Fermi level).
+
+    Primarily this is a copy of ``get_spectra_by_element`` from AiiDA-QE which operates on only one
+    element.
+    """
+    data_dict = {}
+    spectrum_dict = {
+        site: node.outputs.powder_spectrum for site, node in core_wc_dict.items()
+    }
+    for key, value in core_wc_dict.items():
+        xspectra_out_params = value.outputs.parameters_xspectra__xas_0.get_dict()
+        energy_zero = xspectra_out_params['energy_zero']
+        multiplicity = equivalent_sites_dict[key]['multiplicity']
+
+        if 'total_multiplicity' not in data_dict:
+            data_dict['total_multiplicity'] = multiplicity
+        else:
+            data_dict['total_multiplicity'] += multiplicity
+
+        data_dict[key] = {
+            'spectrum_node': spectrum_dict[key],
+            'multiplicity': multiplicity,
+            'energy_zero': energy_zero,
+        }
+
+    spectra_list = []
+    total_multiplicity = data_dict.pop('total_multiplicity')
+    for key in data_dict:
+        spectrum_node = data_dict[key]['spectrum_node']
+        site_multiplicity = data_dict[key]['multiplicity']
+        weighting = site_multiplicity / total_multiplicity
+        weighting_string = f'{site_multiplicity}/{total_multiplicity}'
+        spectrum_x = spectrum_node.get_x()[1]
+        spectrum_y = spectrum_node.get_y()[0][1]
+        spline = make_interp_spline(spectrum_x, spectrum_y)
+        norm_y = spline(spectrum_x) / np.trapz(spline(spectrum_x), spectrum_x)
+        weighted_spectrum = np.column_stack(
+            (spectrum_x, norm_y * (site_multiplicity / total_multiplicity))
+        )
+        spectra_list.append(
+            (
+                weighted_spectrum,
+                key,
+                weighting,
+                weighting_string,
+                float(data_dict[key]['energy_zero']),
+            )
+        )
+
+    # Sort according to Fermi level, then correct to align all spectra to the
+    # highest value. Note that this is needed because XSpectra automatically aligns the
+    # final spectrum such that the system's Fermi level is at 0 eV.
+    spectra_list.sort(key=lambda entry: entry[-1])
+    highest_level = spectra_list[0][-1]
+    energy_zero_corrections = [
+        (entry[0], entry[1], entry[2], entry[3], entry[-1] - highest_level)
+        for entry in spectra_list
+    ]
+    aligned_spectra = [
+        (
+            entry[1],
+            entry[2],
+            entry[3],
+            np.column_stack((entry[0][:, 0] - entry[-1], entry[0][:, 1])),
+        )
+        for entry in energy_zero_corrections
+    ]
+
+    return aligned_spectra

--- a/src/aiida_qe_xspec/gui/xas/setting.py
+++ b/src/aiida_qe_xspec/gui/xas/setting.py
@@ -1,0 +1,235 @@
+"""Panel for XAS plugin."""
+
+import ipywidgets as ipw
+
+from aiidalab_qe.common.panel import ConfigurationSettingsPanel
+
+from .model import XasConfigurationSettingsModel
+
+
+class XasConfigurationSettingsPanel(
+    ConfigurationSettingsPanel[XasConfigurationSettingsModel],
+):
+    # TODO: The element selection should lock the "Confirm" button if no elements have been selected for XAS calculation.
+
+    def __init__(self, model: XasConfigurationSettingsModel, **kwargs):
+        super().__init__(model, **kwargs)
+
+        self._model.observe(
+            self._on_input_structure_change,
+            'input_structure',
+        )
+
+    def render(self):
+        if self.rendered:
+            return
+
+        self.core_hole_treatments_widget = ipw.VBox(layout=ipw.Layout(width='100%'))
+
+        # self.structure_type = ipw.ToggleButtons()
+        # ipw.dlink(
+        #     (self._model, "structure_type_options"),
+        #     (self.structure_type, "options"),
+        # )
+        # ipw.link(
+        #     (self._model, "structure_type"),
+        #     (self.structure_type, "value"),
+        # )
+
+        self.supercell_min_parameter = ipw.FloatText(
+            description='The minimum cell length (Å):',
+            disabled=False,
+            style={'description_width': 'initial'},
+        )
+        ipw.link(
+            (self._model, 'supercell_min_parameter'),
+            (self.supercell_min_parameter, 'value'),
+        )
+
+        self.children = [
+            # I will leave these objects here for now (15/11/23), but since the
+            # calculation of molecular systems is not really supported (neither in
+            # terms of XAS nor the main App itself) we should not present this option
+            # that essentially does nothing.
+            # ipw.HTML("<h4>Structure</h4>"),
+            # ipw.HTML("""
+            #     <div style="line-height: 140%; margin-bottom: 10px">
+            #         Below you can indicate if the material should be treated as a
+            #         molecule or a crystal.
+            #     </div>
+            # """),
+            # ipw.HBox(
+            #     children=[
+            #         self.structure_type,
+            #     ]
+            # ),
+            ipw.HTML('<h4>Element and core-hole treatment settings</h4>'),
+            ipw.HTML("""
+                <div style="line-height: 140%; margin-bottom: 10px;">
+                    To select elements for calculation of K-edge spectra:
+                    <ol>
+                        <li>
+                            Tick the checkbox for each element symbol to select the
+                            element for calculation
+                        </li>
+                        <li>
+                            Select the core-hole treatment scheme from the dropdown box
+                        </li>
+                    </ol>
+                    There are three supported options for core-hole treatment:
+                    <ul>
+                        <li>
+                            FCH: Remove one electron from the system (any occupations
+                            scheme)
+                        </li>
+                        <li>
+                            XCH (Smearing): places the excited electron into the
+                            conduction band (smeared occupations)
+                        </li>
+                        <li>
+                            XCH (Fixed): places the excited electron into the conduction
+                            band (fixed occupations).
+                        </li>
+                    </ul>
+                    <p style="margin-bottom: 10px;">
+                        For XAS calculations of most elements, the FCH treatment is
+                        recommended, however in some cases the XCH treatment should be
+                        used instead.
+                    </p>
+                    <p>
+                        The recommended setting will be shown for each available element.
+                        Note that only elements for which core-hole pseudopotential sets
+                        are available will be shown.
+                    </p>
+                </div>
+            """),
+            ipw.HBox(
+                children=[
+                    self.core_hole_treatments_widget,
+                ],
+                layout=ipw.Layout(width='95%'),
+            ),
+            ipw.HTML("""
+                <div style="margin-top: 15px;">
+                    <h4>Cell size</h4>
+                </div>
+            """),
+            ipw.HTML("""
+                <div style="line-height: 140%; margin-bottom: 10px">
+                    Define the minimum cell length in angstrom for the resulting
+                    supercell, and thus all output structures. The default value of 8.0
+                    angstrom will be used if no input is given. Setting this value to
+                    0.0 will instruct the CF to not scale up the input structure.
+                </div>
+            """),
+            ipw.HBox(
+                children=[
+                    self.supercell_min_parameter,
+                ],
+            ),
+        ]
+
+        self.rendered = True
+
+        self.refresh(specific='widgets')
+
+    def _on_input_structure_change(self, _):
+        self.refresh(specific='structure')
+
+    def update(self, specific=''):
+        if self.updated:
+            return
+        self._show_loading()
+        if not self._model.loaded_from_process or (specific and specific != 'widgets'):
+            self._model.update(specific)
+        self._build_core_hole_treatments_widget()
+        self.updated = True
+
+    def _show_loading(self):
+        if self.rendered:
+            self.core_hole_treatments_widget.children = [self.loading_message]
+
+    def _build_core_hole_treatments_widget(self):
+        if not self.rendered:
+            return
+
+        children = []
+
+        info = 'Recommended: <b>{recommended}</b> (PBE Core-Hole Pseudopotential)'
+
+        for kind_name in self._model.get_kind_names():
+            checkbox = ipw.Checkbox(
+                description=kind_name,
+                disabled=False,
+                style={'description_width': 'initial'},
+                layout=ipw.Layout(width='7%'),
+            )
+            link = ipw.link(
+                (self._model, 'kind_names'),
+                (checkbox, 'value'),
+                [
+                    lambda kinds, kind_name=kind_name: kinds.get(kind_name, False),
+                    lambda value, kind_name=kind_name: {
+                        **self._model.kind_names,
+                        kind_name: value,
+                    },
+                ],
+            )
+            self.links.append(link)
+
+            treatment_selector = ipw.Dropdown(layout=ipw.Layout(width='15%'))
+            options_link = ipw.dlink(
+                (self._model, 'core_hole_treatments_options'),
+                (treatment_selector, 'options'),
+            )
+            value_link = ipw.link(
+                (self._model, 'core_hole_treatments'),
+                (treatment_selector, 'value'),
+                [
+                    lambda treatments, kind_name=kind_name: treatments.get(
+                        kind_name, 'full'
+                    ),
+                    lambda value, kind_name=kind_name: {
+                        **self._model.core_hole_treatments,
+                        kind_name: value,
+                    },
+                ],
+            )
+            self.links.extend([options_link, value_link])
+
+            widget = ipw.HBox(
+                children=[
+                    checkbox,
+                    treatment_selector,
+                    ipw.HTML(
+                        value=info.format(
+                            recommended=self._model.get_recommendation(kind_name)
+                        ),
+                        layout=ipw.Layout(width='78%'),
+                    ),
+                ],
+                layout=ipw.Layout(width='100%'),
+            )
+
+            children.append(widget)
+
+        if not children:
+            children = [ipw.HTML('<b>No elements available for XAS calculations</b>')]
+
+        self.core_hole_treatments_widget.children = children
+
+        # For reference:
+        # This is the whole widget:
+        # print(f"{self.core_hole_treatments_widget}\n")
+
+        # This is the tuple of selected element and core-hole treatment:
+        # print(f"{self.core_hole_treatments_widget.children[0]}\n")
+
+        # This is the checkbox for the element, giving element name and whether to add it to the elements list
+        # print(f"{self.core_hole_treatments_widget.children[0].children[0]}\n")
+        # print(f"{self.core_hole_treatments_widget.children[0].children[0].value}\n")
+        # print(f"{self.core_hole_treatments_widget.children[0].children[0].description}\n")
+
+        # This is the dropdown for the core-hole treatment option:
+        # print(f"{self.core_hole_treatments_widget.children[0].children[1]}\n")
+        # print(f"{self.core_hole_treatments_widget.children[0].children[1].value}\n")

--- a/src/aiida_qe_xspec/gui/xas/structure_examples/Li2CO3.cif
+++ b/src/aiida_qe_xspec/gui/xas/structure_examples/Li2CO3.cif
@@ -1,0 +1,43 @@
+# generated using pymatgen
+data_Li2CO3
+_symmetry_space_group_name_H-M   C2/c
+_cell_length_a   8.28221965
+_cell_length_b   4.96902479
+_cell_length_c   6.07631725
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   113.74593345
+_cell_angle_gamma   90.00000000
+_symmetry_Int_Tables_number   15
+_chemical_formula_structural   Li2CO3
+_chemical_formula_sum   'Li8 C4 O12'
+_cell_volume   228.89737819
+_cell_formula_units_Z   4
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+  2  '-x, -y, -z'
+  3  '-x, y, -z+1/2'
+  4  'x, -y, z+1/2'
+  5  'x+1/2, y+1/2, z'
+  6  '-x+1/2, -y+1/2, -z'
+  7  '-x+1/2, y+1/2, -z+1/2'
+  8  'x+1/2, -y+1/2, z+1/2'
+loop_
+ _atom_type_symbol
+ _atom_type_oxidation_number
+  Li+  1.0
+  C4+  4.0
+  O2-  -2.0
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Li+  Li0  8  0.19639168  0.44656424  0.83739024  1
+  C4+  C1  4  0.00000000  0.06619574  0.25000000  1
+  O2-  O2  8  0.14745362  0.06495296  0.81423924  1
+  O2-  O3  4  0.00000000  0.32319230  0.25000000  1

--- a/src/aiida_qe_xspec/gui/xas/structure_examples/__init__.py
+++ b/src/aiida_qe_xspec/gui/xas/structure_examples/__init__.py
@@ -1,0 +1,10 @@
+import pathlib
+
+file_path = pathlib.Path(__file__).parent
+
+structure_examples = {
+    'title': 'XAS examples',
+    'structures': [
+        ('Lithium carbonate', file_path / 'Li2CO3.cif'),
+    ],
+}

--- a/src/aiida_qe_xspec/gui/xas/workchain.py
+++ b/src/aiida_qe_xspec/gui/xas/workchain.py
@@ -1,0 +1,139 @@
+from importlib import resources
+
+import yaml
+
+from aiida import orm
+from aiida.plugins import WorkflowFactory
+from aiida_quantumespresso.common.types import ElectronicType, SpinType
+from aiidalab_qe.plugins import xas as xas_folder
+from aiidalab_qe.utils import (
+    enable_pencil_decomposition,
+    set_component_resources,
+)
+
+XspectraCrystalWorkChain = WorkflowFactory('quantumespresso.xspectra.crystal')
+PSEUDO_TOC = yaml.safe_load(resources.read_text(xas_folder, 'pseudo_toc.yaml'))
+pseudo_data_dict = PSEUDO_TOC['pseudos']
+xch_elements = PSEUDO_TOC['xas_xch_elements']
+
+
+def update_resources(builder, codes):
+    """Update the resources for the builder."""
+    set_component_resources(builder.core.scf.pw, codes.get('pw'))
+    set_component_resources(builder.core.xs_prod.xspectra, codes.get('xspectra'))
+    enable_pencil_decomposition(builder.core.scf.pw)
+
+
+def get_builder(codes, structure, parameters, **kwargs):
+    from copy import deepcopy
+
+    adv_parameters = deepcopy(parameters['advanced'])
+    # Setting `tot_charge = 0` will cause FCH calculations to fail due to
+    # inputs being incorrect, thus we pop this from the overrides
+    if adv_parameters['pw']['parameters']['SYSTEM'].get('tot_charge') == 0:
+        adv_parameters['pw']['parameters']['SYSTEM'].pop('tot_charge')
+    protocol = parameters['workchain']['protocol']
+    xas_parameters = parameters['xas']
+    core_hole_treatments = xas_parameters['core_hole_treatments']
+    elements_list = xas_parameters['elements_list']
+    supercell_min_parameter = xas_parameters['supercell_min_parameter']
+    pseudo_labels = xas_parameters['pseudo_labels']
+    core_wfc_data_labels = xas_parameters['core_wfc_data_labels']
+    pseudos = {}
+    # Convert the pseudo and core_wfc_data node labels into nodes:
+    core_wfc_data = {k: orm.load_node(v) for k, v in core_wfc_data_labels.items()}
+    for element in elements_list:
+        pseudos[element] = {
+            k: orm.load_node(v) for k, v in pseudo_labels[element].items()
+        }
+
+    # TODO should we override the cutoff_wfc, cutoff_rho by the new pseudo?
+    # In principle we should, if we know what that value is, but that would
+    # require testing them first...
+
+    # (13/10/23) I'm keeping the part about molecules in for future reference,
+    # but we need to establish the protocol & backend code for XAS of molecules
+    # before thinking about a workflow.
+    # (22/01/24) Commented out the code for molecules, just so the option doesn't
+    # appear in the UI and confuse the user.
+    # is_molecule_input = (
+    #     True if xas_parameters.get("structure_type") == "molecule" else False
+    # )
+
+    structure_preparation_settings = {
+        'supercell_min_parameter': orm.Float(supercell_min_parameter),
+        # "is_molecule_input": orm.Bool(is_molecule_input),
+    }
+    spglib_settings = orm.Dict({'symprec': 1.0e-3})
+
+    pw_code = codes['pw']['code']
+    xs_code = codes['xspectra']['code']
+    overrides = {
+        'core': {
+            'scf': adv_parameters,
+            # PG: Here, we set a "variable" broadening scheme, which actually defines a constant broadening
+            # The reason for this is that in "gamma_mode = constant", the Lorenzian broadening parameter
+            # is defined by "xgamma" (in "PLOT"), but this parameter *also* controls the broadening value
+            # used in the Lanczos algorithm to enhance the convergence rate. In order to give the user a
+            # final spectrum with minimal broadening, we use "gamma_mode = variable", which uses a different
+            # parameter set ("gamma_energy(1-2)", "gamma_value(1-2)") and thus allows us to decouple spectrum
+            # broadening from Lanczos broadening and avoid having to re-plot the final spectrum.
+            'xs_prod': {
+                'xspectra': {
+                    'parameters': {
+                        'PLOT': {
+                            'gamma_mode': 'variable',
+                            'gamma_energy(1)': 0,
+                            'gamma_energy(2)': 1,
+                            'gamma_value(1)': 0.1,
+                            'gamma_value(2)': 0.1,
+                        }
+                    }
+                }
+            },
+        }
+    }
+
+    # Ensure that VdW corrections are not applied for the core-hole SCF calculation
+    # Required to resolve issue #765 (https://github.com/aiidalab/aiidalab-qe/issues/765)
+    overrides['core']['scf']['pw']['parameters']['SYSTEM']['vdw_corr'] = 'none'
+
+    builder = XspectraCrystalWorkChain.get_builder_from_protocol(
+        pw_code=pw_code,
+        xs_code=xs_code,
+        structure=structure,
+        protocol=protocol,
+        pseudos=pseudos,
+        elements_list=elements_list,
+        core_hole_treatments=core_hole_treatments,
+        core_wfc_data=core_wfc_data,
+        electronic_type=ElectronicType(parameters['workchain']['electronic_type']),
+        spin_type=SpinType(parameters['workchain']['spin_type']),
+        # TODO: We will need to merge the changes in AiiDA-QE PR#969 in order
+        # to better handle magnetic and Hubbard data. For now, we can probably
+        # leave it as it is.
+        initial_magnetic_moments=parameters['advanced']['initial_magnetic_moments'],
+        overrides=overrides,
+        **kwargs,
+    )
+    builder.pop('relax')
+    builder.pop('clean_workdir', None)
+    builder.spglib_settings = spglib_settings
+    builder.structure_preparation_settings = structure_preparation_settings
+    # update resources
+    update_resources(builder, codes)
+
+    return builder
+
+
+def update_inputs(inputs, ctx):
+    """Update the inputs using context."""
+    inputs.structure = ctx.current_structure
+
+
+workchain_and_builder = {
+    'workchain': XspectraCrystalWorkChain,
+    'exclude': ('structure', 'relax'),
+    'get_builder': get_builder,
+    'update_inputs': update_inputs,
+}


### PR DESCRIPTION
Moves all necessary code for the AiiDAlab XAS app to the aiida-qe-xspec project.

In addition, removes a (now redundant) warning message in the XAS documentation about needing to use v24.04.0a1 or greater.